### PR TITLE
Removing empty author list

### DIFF
--- a/content/Articles/S000021.md
+++ b/content/Articles/S000021.md
@@ -20,7 +20,7 @@ PubAuthorsORCID: 0000-0003-0416-1541
     0000-0002-6913-7545
     0000-0003-4667-9779
 PMRURL: https://models.physiomeproject.org/workspace/763
-PrimaryPaperName: A Theoretical Model of Slow Wave Regulation Using Voltage-Dependent Synthesis of Inositol 1,4,5-Trisphosphate. 2002, None
+PrimaryPaperName: A Theoretical Model of Slow Wave Regulation Using Voltage-Dependent Synthesis of Inositol 1,4,5-Trisphosphate. 2002.
 PrimaryPaperURL: https://doi.org/10.1016/s0006-3495(02)73952-0
 FulltextURL: https://physiome.figshare.com/articles/journal_contribution/A_theoretical_model_of_slow_wave_regulation_using_voltage-dependent_synthesis_of_inositol_1_4_5-trisphosphate/21708176
 ArchiveURL: https://physiome.figshare.com/articles/journal_contribution/A_theoretical_model_of_slow_wave_regulation_using_voltage-dependent_synthesis_of_inositol_1_4_5-trisphosphate/21708176


### PR DESCRIPTION
Autogenerated primary paper citation has an empty author list. Cleaning out for now, but need to resolve at some point.